### PR TITLE
Encode 'service' query parameter in Admin UI logout links

### DIFF
--- a/ui/packages/ui/src/main/webapp/js/application.js
+++ b/ui/packages/ui/src/main/webapp/js/application.js
@@ -145,7 +145,8 @@ define([
         'click button': 'logout',
       },
       logout: function() {
-        window.location.href = '../logout?service=' + window.location.href
+        window.location.href =
+          '../logout?service=' + encodeURIComponent(window.location.href)
       },
     }))()
   )

--- a/ui/packages/ui/src/main/webapp/js/models/SessionTimeout.js
+++ b/ui/packages/ui/src/main/webapp/js/models/SessionTimeout.js
@@ -123,7 +123,9 @@ define(['backbone', 'jquery', 'underscore', 'properties'], function(
       $(document).off('keydown.sessionTimeout mousedown.sessionTimeout')
     },
     logout: function() {
-      window.location.replace(invalidateUrl + window.location.href)
+      window.location.replace(
+        invalidateUrl + encodeURIComponent(window.location.href)
+      )
     },
     renew: function() {
       this.hidePrompt()


### PR DESCRIPTION
### Description
This was inspired by this PR: https://github.com/codice/ddf/pull/6310
I'm not aware of any current bugs caused by the unencoded query parameter, but URIs may contain characters that could cause issues (e.g. `&`). This change is to be safe.

### Reviewers
@blen-desta @bakejeyner @emmberk @garrettfreibott @stustison 