### PR TITLE
Make admin beta ui default

### DIFF
--- a/ui/packages/beta-admin-ui/package.json
+++ b/ui/packages/beta-admin-ui/package.json
@@ -43,5 +43,5 @@
     "src/main/resources"
   ],
   "main": "src/main/webapp/components/entry/entry",
-  "context-path": "/admin/beta"
+  "context-path": "/admin"
 }

--- a/ui/packages/ui/package.json
+++ b/ui/packages/ui/package.json
@@ -63,5 +63,5 @@
     "src/main/resources"
   ],
   "main": "src/main/webapp/main.js",
-  "context-path": "/admin"
+  "context-path": "/admin/old"
 }

--- a/ui/packages/ui/src/main/resources/styleguide.html
+++ b/ui/packages/ui/src/main/resources/styleguide.html
@@ -20,7 +20,7 @@
     <title>Style Guide</title>
     <!-- Stylesheets -->
     <link href="./lib/font-awesome/css/font-awesome.min.css?bust=${timestamp}" rel="stylesheet">
-    <link href="../webjars/css/ddf-theme-flatly.css?bust=${timestamp}" rel="stylesheet">
+    <link href="../../webjars/css/ddf-theme-flatly.css?bust=${timestamp}" rel="stylesheet">
 
 
     <link href="./css/index.css?bust=${timestamp}" rel="stylesheet">

--- a/ui/packages/ui/src/main/webapp/components/application-services/application-services.view.js
+++ b/ui/packages/ui/src/main/webapp/components/application-services/application-services.view.js
@@ -26,7 +26,7 @@ define(['backbone.marionette', 'js/CustomElements'], function(
         <Services
           url={
             this.model
-              ? './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/getServices/' +
+              ? '../../admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/getServices/' +
                 this.model.get('appId')
               : undefined
           }

--- a/ui/packages/ui/src/main/webapp/components/container/configuration/configuration.tsx
+++ b/ui/packages/ui/src/main/webapp/components/container/configuration/configuration.tsx
@@ -19,7 +19,7 @@ import ConfigurationElement, {
 } from '../../presentation/configuration'
 const wreqr = require('js/wreqr.js')
 const configUrl =
-  './jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0'
+  '../admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0'
 const $ = require('jquery')
 const destroy = (id: string) => {
   var deleteUrl = [configUrl, 'delete', id].join('/')

--- a/ui/packages/ui/src/main/webapp/components/iframe/iframe.view.js
+++ b/ui/packages/ui/src/main/webapp/components/iframe/iframe.view.js
@@ -28,7 +28,7 @@ define(['backbone.marionette', './iframe.hbs', 'js/CustomElements'], function(
         </iframe>
       )
       switch (url) {
-        case './logviewer/index.html':
+        case `/admin/logviewer/index.html`:
           Component = AdminLogViewer
           break
       }

--- a/ui/packages/ui/src/main/webapp/components/installer/installer.view.js
+++ b/ui/packages/ui/src/main/webapp/components/installer/installer.view.js
@@ -52,7 +52,7 @@ define([
   var guestClaimsServiceResponse = new Service.Response()
   guestClaimsServiceResponse.fetch({
     url:
-      './jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/getClaimsConfiguration/(service.pid%3Dddf.security.guest.realm)',
+      '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/getClaimsConfiguration/(service.pid%3Dddf.security.guest.realm)',
   })
 
   var ssoConfigurationServiceResponses = new Service.Response()
@@ -73,13 +73,13 @@ define([
       ssoConfigurationServiceResponses.attributes.modified = false
       ssoConfigurationServiceResponses.fetch({
         url:
-          './jolokia/read/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/SsoConfigurations',
+          '../../admin/jolokia/read/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/SsoConfigurations',
       })
     }
   )
   ssoConfigurationServiceResponses.fetch({
     url:
-      './jolokia/read/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/SsoConfigurations',
+      '../../admin/jolokia/read/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/SsoConfigurations',
   })
 
   var systemPropertiesWrapped = new ConfigurationModel.SystemPropertiesWrapped()
@@ -260,7 +260,7 @@ define([
         ssoConfigurationServiceResponses.attributes.fetched = false
         ssoConfigurationServiceResponses.fetch({
           url:
-            './jolokia/read/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/SsoConfigurations',
+            '../../admin/jolokia/read/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/SsoConfigurations',
         })
         this.listenToOnce(
           ssoConfigurationServiceResponses,

--- a/ui/packages/ui/src/main/webapp/components/tab-content/tab-content.view.js
+++ b/ui/packages/ui/src/main/webapp/components/tab-content/tab-content.view.js
@@ -14,6 +14,7 @@
  **/
 /* global define */
 import { iframeResizer } from 'iframe-resizer'
+import { getFixedUrl } from '../../js/util/IframeUtil'
 define([
   'require',
   'backbone.marionette',
@@ -75,18 +76,10 @@ define([
         newView = new newView({ model: view.applicationModel })
         view.tabContentInner.show(newView)
       } else if (iframeLocation) {
-        // only some iframes are brought in as relative
-        const url = iframeLocation
-        const isRelativeUrl = url && url.startsWith('./')
-        let fixedUrl = ''
-        if (url && isRelativeUrl) {
-          fixedUrl = `/admin${url.substring(1)}`
-        } else {
-          fixedUrl = url ? url : ''
-        }
+        const url = getFixedUrl(iframeLocation)
         view.tabContentInner.show(
           new IFrameView({
-            model: new Backbone.Model({ url: fixedUrl }),
+            model: new Backbone.Model({ url }),
           })
         )
       }

--- a/ui/packages/ui/src/main/webapp/components/tab-content/tab-content.view.js
+++ b/ui/packages/ui/src/main/webapp/components/tab-content/tab-content.view.js
@@ -75,9 +75,18 @@ define([
         newView = new newView({ model: view.applicationModel })
         view.tabContentInner.show(newView)
       } else if (iframeLocation) {
+        // only some iframes are brought in as relative
+        const url = iframeLocation
+        const isRelativeUrl = url && url.startsWith('./')
+        let fixedUrl = ''
+        if (url && isRelativeUrl) {
+          fixedUrl = `/admin${url.substring(1)}`
+        } else {
+          fixedUrl = url ? url : ''
+        }
         view.tabContentInner.show(
           new IFrameView({
-            model: new Backbone.Model({ url: iframeLocation }),
+            model: new Backbone.Model({ url: fixedUrl }),
           })
         )
       }

--- a/ui/packages/ui/src/main/webapp/index.html
+++ b/ui/packages/ui/src/main/webapp/index.html
@@ -21,7 +21,7 @@
     <title>Admin Console</title>
     <meta http-equiv="x-ua-compatible" content="IE=Edge">
     <!-- Stylesheets -->
-    <link href="../webjars/css/ddf-theme-flatly.css" rel="stylesheet">
+    <link href="../../webjars/css/ddf-theme-flatly.css" rel="stylesheet">
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>

--- a/ui/packages/ui/src/main/webapp/js/application.js
+++ b/ui/packages/ui/src/main/webapp/js/application.js
@@ -112,7 +112,7 @@ define([
           <div className="panel-heading">
             <h4 className="panel-title clearfix">
               <i className="fa fa-bullhorn" />
-              <a href="beta">Click here to try the new Admin UI</a>
+              <a href="../../admin">Click here to go to the new Admin UI</a>
               <button
                 type="button"
                 className="btn btn-link dismiss"
@@ -146,7 +146,7 @@ define([
       },
       logout: function() {
         window.location.href =
-          '../logout?service=' + encodeURIComponent(window.location.href)
+          '../../logout?service=' + encodeURIComponent(window.location.href)
       },
     }))()
   )

--- a/ui/packages/ui/src/main/webapp/js/models/Alerts.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Alerts.js
@@ -26,7 +26,7 @@ define(['underscore', 'backbone'], function(_, Backbone) {
   AlertsModel.BackendAlerts = Backbone.Collection.extend({
     model: AlertsModel.Alert,
     url:
-      './jolokia/read/org.codice.ddf.ui.admin.api:type=AdminAlertMBean/Alerts',
+      '../../admin/jolokia/read/org.codice.ddf.ui.admin.api:type=AdminAlertMBean/Alerts',
     parse: function(response) {
       return response.value
     },
@@ -54,7 +54,7 @@ define(['underscore', 'backbone'], function(_, Backbone) {
             },
           ]
           json.title =
-            'Your session has expired. Please <a href="/login/index.html?prevurl=/admin/">log in</a> again.'
+            'Your session has expired. Please <a href="/login/index.html?prevurl=/admin/old">log in</a> again.'
         }
         return json
       } else {

--- a/ui/packages/ui/src/main/webapp/js/models/AppConfigPlugin.js
+++ b/ui/packages/ui/src/main/webapp/js/models/AppConfigPlugin.js
@@ -21,7 +21,7 @@ define(['backbone', 'underscore'], function(Backbone, _) {
   AppConfigPlugin.Collection = Backbone.Collection.extend({
     model: AppConfigPlugin.Model,
     url:
-      './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/getPluginsForApplication(java.lang.String)/',
+      '../../admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/getPluginsForApplication(java.lang.String)/',
     fetchByAppName: function(appName, options) {
       var collection = this
 

--- a/ui/packages/ui/src/main/webapp/js/models/ApplicationsLayout.js
+++ b/ui/packages/ui/src/main/webapp/js/models/ApplicationsLayout.js
@@ -149,7 +149,7 @@ define(['backbone', 'jquery', 'underscore'], function(Backbone, $, _) {
   Applications.TreeNodeCollection = Backbone.Collection.extend({
     model: Applications.TreeNode,
     url:
-      './jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/Applications/',
+      '../../admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/Applications/',
 
     comparator: function(model) {
       return model.get('displayName')
@@ -168,7 +168,7 @@ define(['backbone', 'jquery', 'underscore'], function(Backbone, $, _) {
         applicationsResponseCache = $.ajax({
           type: 'GET',
           url:
-            './jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/Applications/',
+            '../../admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/Applications/',
           dataType: 'JSON',
         }).then(function(appsResp) {
           return appsResp.value

--- a/ui/packages/ui/src/main/webapp/js/models/InstallProfile.js
+++ b/ui/packages/ui/src/main/webapp/js/models/InstallProfile.js
@@ -29,7 +29,7 @@ define(['backbone', 'underscore'], function(Backbone, _) {
     model: InstallProfile.Model,
     sortNames: ['standard', 'full'],
     url:
-      './jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/InstallationProfiles/',
+      '../../admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/InstallationProfiles/',
     parse: function(resp) {
       return resp.value
     },

--- a/ui/packages/ui/src/main/webapp/js/models/Installer.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Installer.js
@@ -47,11 +47,11 @@ define(['backbone', 'underscore', 'jquery', 'js/wreqr'], function(
 
   Installer.Model = Backbone.Model.extend({
     installUrl:
-      './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/',
+      '../../admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/',
     uninstallUrl:
-      './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/uninstallFeature(java.lang.String)/',
+      '../../admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/uninstallFeature(java.lang.String)/',
     restartUrl:
-      './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/restart()/',
+      '../../admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/restart()/',
     defaults: function() {
       return {
         hasNext: true,

--- a/ui/packages/ui/src/main/webapp/js/models/Module.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Module.js
@@ -19,7 +19,7 @@ define(['backbone', 'backbone-relational'], function(Backbone) {
   var moduleCollection = Backbone.Collection.extend({ model: module })
   Module.Model = Backbone.RelationalModel.extend({
     url:
-      './jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/listModules',
+      '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/listModules',
     relations: [
       {
         type: Backbone.HasMany,

--- a/ui/packages/ui/src/main/webapp/js/models/Service.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Service.js
@@ -54,7 +54,7 @@ define([
 
   Service.Configuration = Backbone.AssociatedModel.extend({
     configUrl:
-      './jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0',
+      '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0',
 
     defaults: function() {
       return {
@@ -281,7 +281,7 @@ define([
 
   Service.Model = Backbone.AssociatedModel.extend({
     configUrl:
-      './jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0',
+      '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0',
 
     defaults: function() {
       return {
@@ -366,7 +366,7 @@ define([
         this.url = options.url
       } else {
         this.url =
-          './jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/listServices'
+          '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/listServices'
       }
     },
   })

--- a/ui/packages/ui/src/main/webapp/js/models/SessionTimeout.js
+++ b/ui/packages/ui/src/main/webapp/js/models/SessionTimeout.js
@@ -13,7 +13,7 @@
  *
  **/
 
-var invalidateUrl = '../services/internal/session/invalidate?service='
+var invalidateUrl = '../../services/internal/session/invalidate?service='
 
 var idleNoticeDuration = 60000
 // Length of inactivity that will trigger user timeout (15 minutes in ms by default)

--- a/ui/packages/ui/src/main/webapp/js/models/features/feature.js
+++ b/ui/packages/ui/src/main/webapp/js/models/features/feature.js
@@ -17,11 +17,11 @@ define(['backbone', 'jquery', 'underscore'], function(Backbone, $, _) {
   var Feature = {}
 
   var featureUrl =
-    './jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/AllFeatures'
+    '../../admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/AllFeatures'
   var installUrl =
-    './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/'
+    '../../admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/'
   var uninstallUrl =
-    './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/uninstallFeature(java.lang.String)/'
+    '../../admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/uninstallFeature(java.lang.String)/'
 
   Feature.Model = Backbone.Model.extend({
     initialize: function(options) {

--- a/ui/packages/ui/src/main/webapp/js/models/installer/CertsModel.js
+++ b/ui/packages/ui/src/main/webapp/js/models/installer/CertsModel.js
@@ -112,7 +112,7 @@ define(['backbone.marionette', 'underscore', 'backbone', 'jquery'], function(
         type: 'POST',
         contentType: 'application/json',
         data: jdata,
-        url: './jolokia/exec/' + data.mbean + '/' + data.operation,
+        url: '../../admin/jolokia/exec/' + data.mbean + '/' + data.operation,
       }).done(function(result) {
         if (!model.get('devMode')) {
           model.set('certErrors', JSON.parse(result).value)

--- a/ui/packages/ui/src/main/webapp/js/models/installer/Configuration.js
+++ b/ui/packages/ui/src/main/webapp/js/models/installer/Configuration.js
@@ -51,9 +51,9 @@ define(['backbone', 'jquery', 'backboneassociations'], function(Backbone, $) {
   Configuration.SystemProperties = Backbone.Collection.extend({
     model: Configuration.SystemProperty,
     url:
-      './jolokia/exec/org.codice.ddf.ui.admin.api:type=SystemPropertiesAdminMBean/readSystemProperties',
+      '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api:type=SystemPropertiesAdminMBean/readSystemProperties',
     saveUrl:
-      './jolokia/exec/org.codice.ddf.ui.admin.api:type=SystemPropertiesAdminMBean/writeSystemProperties',
+      '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api:type=SystemPropertiesAdminMBean/writeSystemProperties',
     parse: function(response) {
       // Return the value which will be the list of system property objects
       return response.value

--- a/ui/packages/ui/src/main/webapp/js/models/module/ModulePlugin.js
+++ b/ui/packages/ui/src/main/webapp/js/models/module/ModulePlugin.js
@@ -21,7 +21,7 @@ define(['backbone', 'underscore'], function(Backbone, _) {
   ModulePlugin.Collection = Backbone.Collection.extend({
     model: ModulePlugin.Model,
     url:
-      './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/getPluginsForModule(java.lang.String)/',
+      '../../admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/getPluginsForModule(java.lang.String)/',
     fetchByModuleName: function(moduleName, options) {
       var collection = this
 

--- a/ui/packages/ui/src/main/webapp/js/models/module/OperatingSystem.js
+++ b/ui/packages/ui/src/main/webapp/js/models/module/OperatingSystem.js
@@ -20,7 +20,7 @@ define(['backbone'], function(Backbone) {
     defaults: {
       fetched: false,
     },
-    url: './jolokia/read/java.lang:type=OperatingSystem/',
+    url: '../../admin/jolokia/read/java.lang:type=OperatingSystem/',
     parse: function(resp) {
       resp.value.fetched = true
       return resp.value

--- a/ui/packages/ui/src/main/webapp/js/models/module/SystemInformation.js
+++ b/ui/packages/ui/src/main/webapp/js/models/module/SystemInformation.js
@@ -20,7 +20,7 @@ define(['backbone'], function(Backbone) {
     defaults: {
       fetched: false,
     },
-    url: './jolokia/read/java.lang:type=Runtime/',
+    url: '../../admin/jolokia/read/java.lang:type=Runtime/',
     parse: function(resp) {
       resp.value.fetched = true
       return resp.value

--- a/ui/packages/ui/src/main/webapp/js/util/IframeUtil.js
+++ b/ui/packages/ui/src/main/webapp/js/util/IframeUtil.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+export const getFixedUrl = url => {
+  // only some iframes are brought in as relative
+  const isRelativeUrl = url && url.startsWith('./')
+  let fixedUrl = ''
+  if (url && isRelativeUrl) {
+    fixedUrl = `/admin${url.substring(1)}`
+  } else {
+    fixedUrl = url ? url : ''
+  }
+  return fixedUrl
+}

--- a/ui/packages/ui/src/main/webapp/js/util/SessionRefresherUtil.js
+++ b/ui/packages/ui/src/main/webapp/js/util/SessionRefresherUtil.js
@@ -14,7 +14,7 @@
  **/
 
 define(['backbone', 'jquery'], function(Backbone, $) {
-  var sessionExpiryUrl = '../services/internal/session/expiry'
+  var sessionExpiryUrl = '../../services/internal/session/expiry'
 
   var sessionAutoRenewModel = new (Backbone.Model.extend({
     defaults: {

--- a/ui/packages/ui/src/main/webapp/js/views/Alerts.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/Alerts.view.js
@@ -22,7 +22,7 @@ define([
   var AlertsView = {}
 
   var dismissUrl =
-    './jolokia/exec/org.codice.ddf.ui.admin.api:type=AdminAlertMBean/dismissAlert'
+    '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api:type=AdminAlertMBean/dismissAlert'
 
   AlertsView.View = Marionette.ItemView.extend({
     template: alertsTemplate,

--- a/ui/packages/ui/src/main/webapp/js/views/Module.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/Module.view.js
@@ -15,6 +15,7 @@
 
 import * as React from 'react'
 import { iframeResizer } from 'iframe-resizer'
+import { getFixedUrl } from '../util/IframeUtil'
 define([
   'backbone.marionette',
   'jquery',
@@ -119,16 +120,8 @@ define([
                 this.model.get('iframeLocation') &&
                 this.model.get('iframeLocation') !== ''
               ) {
-                // only some iframes are brought in as relative
-                const url = this.model.get('iframeLocation')
-                const isRelativeUrl = url && url.startsWith('./')
-                let fixedUrl = ''
-                if (url && isRelativeUrl) {
-                  fixedUrl = `/admin${url.substring(1)}`
-                } else {
-                  fixedUrl = url ? url : ''
-                }
-                this.$el.html('<iframe src="' + fixedUrl + '"></iframe>')
+                const url = getFixedUrl(this.model.get('iframeLocation'))
+                this.$el.html('<iframe src="' + url + '"></iframe>')
               } else {
                 if (Application.App[this.model.get('name')]) {
                   //the require([]) function uses setTimeout internally to make this call asynchronously

--- a/ui/packages/ui/src/main/webapp/js/views/Module.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/Module.view.js
@@ -119,11 +119,16 @@ define([
                 this.model.get('iframeLocation') &&
                 this.model.get('iframeLocation') !== ''
               ) {
-                this.$el.html(
-                  '<iframe src="' +
-                    this.model.get('iframeLocation') +
-                    '"></iframe>'
-                )
+                // only some iframes are brought in as relative
+                const url = this.model.get('iframeLocation')
+                const isRelativeUrl = url && url.startsWith('./')
+                let fixedUrl = ''
+                if (url && isRelativeUrl) {
+                  fixedUrl = `/admin${url.substring(1)}`
+                } else {
+                  fixedUrl = url ? url : ''
+                }
+                this.$el.html('<iframe src="' + fixedUrl + '"></iframe>')
               } else {
                 if (Application.App[this.model.get('name')]) {
                   //the require([]) function uses setTimeout internally to make this call asynchronously

--- a/ui/packages/ui/src/main/webapp/js/views/installer/Certificate.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/installer/Certificate.view.js
@@ -68,7 +68,7 @@ define([
       var view = this
       var el = this.$('.' + name + '-fileupload')
       el.fileupload({
-        url: '../services/content',
+        url: '../../services/content',
         paramName: 'file',
         dataType: 'json',
         maxFileSize: 5000000,

--- a/ui/packages/ui/src/main/webapp/js/views/installer/GuestClaims.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/installer/GuestClaims.view.js
@@ -463,7 +463,7 @@ define([
         contentType: 'application/json',
         data: JSON.stringify(data),
         url:
-          './jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/add',
+          '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/add',
       })
     },
     validate: function() {

--- a/ui/packages/ui/src/main/webapp/js/views/installer/Profile.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/installer/Profile.view.js
@@ -74,7 +74,7 @@ define([
       $.ajax({
         type: 'GET',
         url:
-          './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/' +
+          '../../admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/' +
           profile,
         dataType: 'JSON',
         success: function(data) {

--- a/ui/packages/ui/src/main/webapp/js/views/installer/SsoConfiguration.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/installer/SsoConfiguration.view.js
@@ -163,7 +163,7 @@ define([
         contentType: 'application/json',
         data: JSON.stringify(data),
         url:
-          './jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0',
+          '../../admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0',
         success: function() {
           wreqr.vent.trigger('ssoConfigPersisted')
         },

--- a/ui/packages/ui/src/main/webapp/properties.js
+++ b/ui/packages/ui/src/main/webapp/properties.js
@@ -30,7 +30,7 @@ define(['jquery'], function($) {
         async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
         cache: false,
         dataType: 'json',
-        url: '../services/platform/config/ui',
+        url: '../../services/platform/config/ui',
       })
         .done(function(uiConfig) {
           props.ui = uiConfig
@@ -52,7 +52,7 @@ define(['jquery'], function($) {
         async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
         cache: false,
         dataType: 'json',
-        url: '../services/admin/config',
+        url: '../../services/admin/config',
       })
         .done(function(adminConfig) {
           props.admin = adminConfig


### PR DESCRIPTION
Hero instructions/considerations:
Anything kanri-related should be fine since I limited route changes to files in ui/packages/ui . You could give it a once over if you want though. For the old admin ui, you'd want to make sure:
1. the installer works as expected
2. content that uses iframes (map layers, layout, etc.) display / behave properly (adding, saving, deleting things)
3. Verify that changes made are reflected in the ui

Routes `/admin` to the beta admin ui.
![image](https://user-images.githubusercontent.com/4467636/110560002-73580c80-8102-11eb-8ff8-d580cf78c514.png)


Routes `/admin/old` to the old admin ui.
![image](https://user-images.githubusercontent.com/4467636/110560060-8f5bae00-8102-11eb-9781-bd6175cf5080.png)

Other routes (e.g. `/admin/map-layers`, `/admin/sources`) are unchanged.